### PR TITLE
Bugfixes when echoing values to logs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -116,7 +116,7 @@ runs:
         7z x -so "$local_name" -p"${{ inputs.password }}" | tar xf - -C "${{ inputs.destination }}"
 
     - name: Check Artifact Contents
-      if: ${{ inputs.reset-retention == 'false' }}
+      if: ${{ inputs.reset-retention == 'false' && runner.debug == 1 }}
       shell: bash
       run: |
         echo "INFO: Checking artifact contents"

--- a/action.yml
+++ b/action.yml
@@ -120,7 +120,7 @@ runs:
       shell: bash
       run: |
         echo "INFO: Checking artifact contents"
-        ls -l "${{ inputs.destination }}"
+        ls -la "${{ inputs.destination }}"
 
     - name: Upload Artifact
       id: upload

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ inputs:
       uploads the artifact again to GitHub and overwrites the old copy, resulting in a new artifact ID. This resets
       the artifact's retention period and when run on a regular schedule, circumvents GitHub's artifact retention limits.
     required: false
-    default: false
+    default: "false"
 
 outputs:
   artifact-id:

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,9 @@ runs:
       shell: bash
       run: |
         echo "DEBUG: Printing values of input variables"
-        echo "${{ toJSON(inputs) }}"
+        echo "${INPUTS_JSON}"
+      env:
+        INPUTS_JSON: ${{ toJSON(inputs) }}
 
     - name: Get Workflow Run ID
       id: get-workflow-run-id

--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,7 @@ runs:
   steps:
     - name: Print Inputs
       shell: bash
+      if: ${{ runner.debug == 1 }}
       run: |
         echo "DEBUG: Printing values of input variables"
         echo "${INPUTS_JSON}"

--- a/action.yml
+++ b/action.yml
@@ -50,15 +50,18 @@ runs:
   using: composite
 
   steps:
+    - name: Mask Necessary Inputs
+      shell: bash
+      run: echo "::add-mask::$PASS_INPUT"
+      env:
+        PASS_INPUT: ${{ inputs.password }}
+
     - name: Print Inputs
       shell: bash
       if: ${{ runner.debug == 1 }}
-      run: |
-        echo "::add-mask::$PASS_INPUT"
-        echo "::debug::Values of input variables\n${INPUTS_JSON}"
+      run: echo "::debug::Values of input variables\n${INPUTS_JSON}"
       env:
         INPUTS_JSON: ${{ toJSON(inputs) }}
-        PASS_INPUT: ${{ inputs.password }}
 
     - name: Get Workflow Run ID
       id: get-workflow-run-id

--- a/action.yml
+++ b/action.yml
@@ -54,10 +54,11 @@ runs:
       shell: bash
       if: ${{ runner.debug == 1 }}
       run: |
-        echo "DEBUG: Printing values of input variables"
-        echo "${INPUTS_JSON}"
+        echo "::add-mask::$PASS_INPUT"
+        echo "::debug::Values of input variables\n${INPUTS_JSON}"
       env:
         INPUTS_JSON: ${{ toJSON(inputs) }}
+        PASS_INPUT: ${{ inputs.password }}
 
     - name: Get Workflow Run ID
       id: get-workflow-run-id


### PR DESCRIPTION
I ran into a bug with the action when it echoes the input information to the logs at the beginning of the action. Seems like special characters in the password input were causing problems in Bash, which resulted in the action failing. I moved the `toJson()` call into an environment variable, which means Bash can properly escape it as a simple string. I also added a few other minor tweaks:

* Steps that provide debug output (listing files in the archive, etc) only execute when the run is in debug mode.
* `password` input is masked in case the caller forgot to do it themselves